### PR TITLE
Add CLI tool to score CVs against job offers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,15 @@ python3 script/cv_evaluator.py oferta.txt cv.txt --top-n 25 --extra-keyword pyth
 
 Add `--json` if you prefer machine-readable output that can be used from other
 scripts.
+
+### Szybki start z przykładowymi danymi
+
+W katalogu [`examples/`](examples/) znajdziesz przykładową ofertę pracy oraz CV.
+Dzięki temu możesz od razu uruchomić narzędzie i zobaczyć raport:
+
+```bash
+python3 script/cv_evaluator.py examples/offer.txt examples/cv.txt
+```
+
+Otrzymasz wynik z listą dopasowanych i brakujących słów kluczowych, co ułatwia
+szybką ocenę skuteczności narzędzia.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,23 @@ I'm the GitHub Learning Lab bot and I'm here to help guide you in your journey t
 I'll meet you over there, can't wait to get started!
 
 This course is using the :sparkles: open source project [reveal.js](https://github.com/hakimel/reveal.js/). In some cases we’ve made changes to the history so it would behave during class, so head to the original project repo to learn more about the cool people behind this project.
+
+## CV evaluation helper
+
+This repository now also contains a small command line tool that helps you check
+how well a CV matches a specific job offer. The script analyses the most
+important keywords in the offer and reports which of them are present in the CV.
+
+```bash
+python3 script/cv_evaluator.py oferta.txt cv.txt
+```
+
+Use `--top-n` to limit the number of keywords taken from the offer and
+`--extra-keyword` to add your own must-have requirements:
+
+```bash
+python3 script/cv_evaluator.py oferta.txt cv.txt --top-n 25 --extra-keyword python --extra-keyword django
+```
+
+Add `--json` if you prefer machine-readable output that can be used from other
+scripts.

--- a/examples/cv.txt
+++ b/examples/cv.txt
@@ -1,0 +1,22 @@
+Jan Kowalski
+
+Doświadczony Software Engineer z 5-letnim stażem w tworzeniu aplikacji backendowych.
+
+Umiejętności techniczne:
+- Python, Django, FastAPI, Flask
+- projektowanie REST API
+- PostgreSQL, MySQL, Redis
+- Docker, docker-compose, podstawy Kubernetes
+- CI/CD: GitHub Actions, Jenkins
+- komunikacja w języku angielskim (B2)
+
+Doświadczenie:
+2021 - obecnie: Senior Python Developer w DataFlow
+- tworzenie mikroserwisów do przetwarzania danych
+- optymalizacja zapytań SQL
+- współpraca z zespołem DevOps przy wdrażaniu na Kubernetes
+
+2018 - 2021: Python Developer w WebApps
+- rozwój aplikacji webowych w Django
+- projektowanie i implementacja REST API
+- utrzymanie i automatyzacja pipeline'ów CI/CD

--- a/examples/offer.txt
+++ b/examples/offer.txt
@@ -1,0 +1,13 @@
+Poszukujemy doświadczonego Python Developera do pracy nad systemem analizy danych.
+
+Wymagania:
+- bardzo dobra znajomość Python, Django, REST API
+- doświadczenie z bazami danych PostgreSQL
+- praktyczna znajomość Docker i Kubernetes
+- mile widziana znajomość narzędzi do CI/CD (GitHub Actions, GitLab CI)
+- dobra znajomość języka angielskiego
+
+Obowiązki:
+- projektowanie i rozwijanie mikroserwisów
+- współpraca z zespołem DevOps
+- optymalizacja zapytań do bazy danych

--- a/script/cv_evaluator.py
+++ b/script/cv_evaluator.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Simple CV evaluation tool based on a job offer.
+
+The script compares the keywords present in a job offer against the
+content of a CV/resume and returns a similarity score together with
+matched and missing requirements. It is intentionally lightweight and
+only depends on the Python standard library so it can be used without
+additional setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Set
+
+# The stop words list is deliberately a mix of English and Polish words because
+# job offers and CVs often combine both languages. This helps the tool focus on
+# actual requirements such as technologies or responsibilities instead of
+# generic verbs.
+STOP_WORDS: Set[str] = {
+    "a",
+    "aby",
+    "and",
+    "as",
+    "at",
+    "be",
+    "being",
+    "by",
+    "czy",
+    "dla",
+    "do",
+    "from",
+    "i",
+    "in",
+    "is",
+    "it",
+    "jego",
+    "jej",
+    "jest",
+    "na",
+    "o",
+    "of",
+    "or",
+    "our",
+    "przez",
+    "s",
+    "się",
+    "the",
+    "to",
+    "u",
+    "was",
+    "we",
+    "with",
+    "w",
+    "you",
+    "że",
+}
+
+TOKEN_RE = re.compile(r"[a-ząćęłńóśźż0-9\+#\-]+", re.IGNORECASE)
+
+
+def tokenize(text: str) -> List[str]:
+    """Return a list of lower-cased tokens contained in *text*."""
+
+    return [token.lower() for token in TOKEN_RE.findall(text)]
+
+
+def extract_keywords(tokens: Sequence[str], *, top_n: int) -> List[str]:
+    """Extract the *top_n* most frequent keywords from *tokens*.
+
+    The function filters out stop words and very short words to focus on
+    meaningful requirements. The resulting list is sorted from most frequent to
+    least frequent.
+    """
+
+    filtered = [t for t in tokens if len(t) > 2 and t not in STOP_WORDS]
+    counter = Counter(filtered)
+    return [token for token, _ in counter.most_common(top_n)]
+
+
+@dataclass
+class EvaluationResult:
+    score: float
+    offer_keywords: List[str]
+    matched_keywords: List[str]
+    missing_keywords: List[str]
+    offer_path: pathlib.Path
+    cv_path: pathlib.Path
+
+    def as_report(self) -> str:
+        lines = [
+            f"Oferta: {self.offer_path}",
+            f"CV: {self.cv_path}",
+            f"Wynik dopasowania: {self.score:.1f}/100",
+            "",
+            f"Dopasowane słowa kluczowe ({len(self.matched_keywords)}/"
+            f"{len(self.offer_keywords)}):",
+            ", ".join(self.matched_keywords) or "(brak)",
+            "",
+            f"Brakujące słowa kluczowe ({len(self.missing_keywords)}):",
+            ", ".join(self.missing_keywords) or "(brak)",
+        ]
+        return "\n".join(lines)
+
+
+def evaluate_cv(
+    offer_text: str,
+    cv_text: str,
+    *,
+    top_n: int,
+    extra_keywords: Iterable[str] | None = None,
+) -> EvaluationResult:
+    offer_tokens = tokenize(offer_text)
+    cv_tokens = tokenize(cv_text)
+
+    offer_keywords = extract_keywords(offer_tokens, top_n=top_n)
+    if extra_keywords:
+        offer_keywords = list(dict.fromkeys(list(extra_keywords) + offer_keywords))
+
+    cv_counter = Counter(cv_tokens)
+    cv_token_set = set(cv_counter)
+
+    matched = [kw for kw in offer_keywords if kw in cv_token_set]
+    missing = [kw for kw in offer_keywords if kw not in cv_token_set]
+
+    if not offer_keywords:
+        score = 0.0
+    else:
+        coverage = len(matched) / len(offer_keywords)
+        density = (
+            sum(cv_counter[kw] for kw in matched) / max(sum(cv_counter.values()), 1)
+        )
+        score = (coverage * 0.7 + density * 0.3) * 100
+
+    return EvaluationResult(
+        score=score,
+        offer_keywords=offer_keywords,
+        matched_keywords=matched,
+        missing_keywords=missing,
+        offer_path=pathlib.Path("offer"),  # placeholders replaced in main()
+        cv_path=pathlib.Path("cv"),
+    )
+
+
+def load_text(path: pathlib.Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        # Retry with latin-1 which is often used for CVs exported from legacy tools.
+        return path.read_text(encoding="latin-1")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Analizuje zgodność CV z ofertą pracy na podstawie słów kluczowych."
+            " Im wyższy wynik, tym więcej wymagań z oferty znajduje się w CV."
+        )
+    )
+    parser.add_argument(
+        "offer",
+        type=pathlib.Path,
+        help="Ścieżka do pliku tekstowego z ofertą pracy.",
+    )
+    parser.add_argument(
+        "cv",
+        type=pathlib.Path,
+        help="Ścieżka do pliku tekstowego z CV.",
+    )
+    parser.add_argument(
+        "--top-n",
+        type=int,
+        default=40,
+        help="Liczba najważniejszych słów kluczowych z oferty, które będą oceniane.",
+    )
+    parser.add_argument(
+        "--extra-keyword",
+        action="append",
+        default=[],
+        help=(
+            "Dodatkowe słowo kluczowe, które zawsze powinno być oceniane. "
+            "Argument można powtórzyć wielokrotnie."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Zwróć wynik w formacie JSON (przydatne do automatyzacji).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    offer_text = load_text(args.offer)
+    cv_text = load_text(args.cv)
+
+    result = evaluate_cv(
+        offer_text,
+        cv_text,
+        top_n=max(args.top_n, 1),
+        extra_keywords=args.extra_keyword,
+    )
+    result.offer_path = args.offer
+    result.cv_path = args.cv
+
+    if args.json:
+        import json
+
+        payload = {
+            "offer": str(result.offer_path),
+            "cv": str(result.cv_path),
+            "score": round(result.score, 2),
+            "offer_keywords": result.offer_keywords,
+            "matched_keywords": result.matched_keywords,
+            "missing_keywords": result.missing_keywords,
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(result.as_report())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python-based command line tool that scores how well a CV matches a job offer using keyword coverage
- document how to run the evaluator and tweak its options in the README

## Testing
- python3 script/cv_evaluator.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ed57f5b388832c9f9b078103174462